### PR TITLE
fix: Fix planVersion type Number

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -96,7 +96,7 @@ ___TEMPLATE_PARAMETERS___
     "help": "Data Plan ID and Version allow you to select specific data plans to validate and control your data."
   },
   {
-    "type": "NUMBER",
+    "type": "TEXT",
     "name": "planVersion",
     "displayName": "Data Plan Version",
     "simpleValueType": true,
@@ -114,13 +114,14 @@ const setInWindow = require('setInWindow');
 const copyFromWindow = require('copyFromWindow'); 
 const callInWindow = require('callInWindow'); 
 const queryPermission = require('queryPermission');
+const makeNumber = require('makeNumber');
 log('data =', data);
 
 const dataPlanObject = {}; 
 
 if (data.planId && data.planVersion) {
   dataPlanObject.planId = data.planId; 
-  dataPlanObject.planVersion = data.planVersion; 
+  dataPlanObject.planVersion = makeNumber(data.planVersion); 
 } 
 
 const mParticleObject = {


### PR DESCRIPTION
Resetting planVersion type to TEXT and adding number transformation to match type validation in sdk
- NUMBER is not a valid type for GTM, so we need to use TEXT
- I've added an GTM API function to transform the text to number and comply with the [data type validation](https://github.com/mParticle/mparticle-web-sdk/blob/4740596cb9f19e968e74c4d3c103d50c846d0888/src/store.ts#L359) from our SDK